### PR TITLE
C13 fractionation factors and ratios

### DIFF
--- a/Fsea2air.m
+++ b/Fsea2air.m
@@ -93,7 +93,9 @@ function vout = Fsea2air(par, Gtype)
         vout.JgDIC = tmp(iwet) ; % umole/kg/s to mmol/m^3/s
         
         % the equilibrium fractionation factor from aqueous CO2 to particulate organic carbon (POC) 
-        par.c13.alpha_dic2poc = −0.017*log(co2surf) + 1.0034; % check the unit of co2surf
+        par.c13.alpha_aq2poc = −0.017*log(co2surf) + 1.0034; % check the unit of co2surf
+        par.c13.alpha_dic2poc = par.c13.alpha_g2aq./par.c13.alpha_g2dic*par.c13.alpha_aq2poc; 
+
 
         % Gradient
         [co2surf,k0,Gout] = eqco2(vDICs,vALKs,co2syspar) ;


### PR DESCRIPTION
@fprimeau hi, Francois, I added the fractionation factors from A. Schmittner. The new parameters were added as par.c13.XXX. With these parameters and eqco2, we can calculate the F_c13. I guess we need a free parameter R13o (ocean DIC13/(DIC total)), which can later be determined by the Newton's method. 
In the paper, there is also a fractionation factor for DIC to POC, which depends on the co2surf. I don't find the DOC-related fractionation factors. 
I have a question here. if we modify the eqCcyle to eqC13cycle, we can solve the C13 equilibrium state here. We don't need to go back to the codes we were working last week except for the transient run, correct?
If we want to optimize the C13 parameters later, we need the gradients. I don't change those now because I am not sure how to modify the eqco2 to C13. 
I think we can look at the codes tomorrow and quickly fix something.

Best
Weiwei